### PR TITLE
Add initial MSTest project with basic tests

### DIFF
--- a/Project_Trade_Auto.sln
+++ b/Project_Trade_Auto.sln
@@ -5,17 +5,23 @@ VisualStudioVersion = 16.0.33529.622
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Trade_auto_Kiwoom", "Trade_auto_Kiwoom.csproj", "{F5DA41D4-8894-4B36-A5C6-A769421051EE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Trade_Csharp_25.Tests", "Tests\\Trade_Csharp_25.Tests.csproj", "{1E8C1C70-4F1D-4FB2-A8F2-6C3A27CE3C03}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{F5DA41D4-8894-4B36-A5C6-A769421051EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F5DA41D4-8894-4B36-A5C6-A769421051EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F5DA41D4-8894-4B36-A5C6-A769421051EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F5DA41D4-8894-4B36-A5C6-A769421051EE}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {F5DA41D4-8894-4B36-A5C6-A769421051EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {F5DA41D4-8894-4B36-A5C6-A769421051EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {F5DA41D4-8894-4B36-A5C6-A769421051EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {F5DA41D4-8894-4B36-A5C6-A769421051EE}.Release|Any CPU.Build.0 = Release|Any CPU
+                {1E8C1C70-4F1D-4FB2-A8F2-6C3A27CE3C03}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {1E8C1C70-4F1D-4FB2-A8F2-6C3A27CE3C03}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {1E8C1C70-4F1D-4FB2-A8F2-6C3A27CE3C03}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {1E8C1C70-4F1D-4FB2-A8F2-6C3A27CE3C03}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/Tests/FormTests.cs
+++ b/Tests/FormTests.cs
@@ -1,0 +1,44 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using WindowsFormsApp1;
+
+namespace Trade_Csharp_25.Tests
+{
+    [TestClass]
+    public class FormTests
+    {
+        [TestMethod]
+        public void TradeAuto_HasAuthenticationKey()
+        {
+            Assert.IsFalse(string.IsNullOrWhiteSpace(Trade_Auto.Authentication));
+        }
+
+        [TestMethod]
+        public void SettingForm_HasTradeAutoConstructor()
+        {
+            var ctor = typeof(Setting).GetConstructor(new[] { typeof(Trade_Auto) });
+            Assert.IsNotNull(ctor);
+        }
+
+        [TestMethod]
+        public void TransactionForm_HasParameterlessConstructor()
+        {
+            var ctor = typeof(Transaction).GetConstructor(Type.EmptyTypes);
+            Assert.IsNotNull(ctor);
+        }
+
+        [TestMethod]
+        public void LogForm_HasParameterlessConstructor()
+        {
+            var ctor = typeof(Log).GetConstructor(Type.EmptyTypes);
+            Assert.IsNotNull(ctor);
+        }
+
+        [TestMethod]
+        public void UpdateForm_HasTradeAutoConstructor()
+        {
+            var ctor = typeof(Update).GetConstructor(new[] { typeof(Trade_Auto) });
+            Assert.IsNotNull(ctor);
+        }
+    }
+}

--- a/Tests/Trade_Csharp_25.Tests.csproj
+++ b/Tests/Trade_Csharp_25.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Trade_auto_Kiwoom.csproj" />
+  </ItemGroup>
+</Project>

--- a/Tests/UtilityKISTests.cs
+++ b/Tests/UtilityKISTests.cs
@@ -1,0 +1,24 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WindowsFormsApp1;
+
+namespace Trade_Csharp_25.Tests
+{
+    [TestClass]
+    public class UtilityKISTests
+    {
+        [TestMethod]
+        public void Constructor_InitializesFieldsFromUtility()
+        {
+            utility.KIS_Account = "12345678-01";
+            utility.KIS_appkey = "app";
+            utility.KIS_appsecret = "secret";
+
+            var kis = new utility_KIS();
+
+            Assert.AreEqual("12345678", kis.cano);
+            Assert.AreEqual("01", kis.acntPrdtCd);
+            Assert.AreEqual("app", kis.appKey);
+            Assert.AreEqual("secret", kis.secretkey);
+        }
+    }
+}

--- a/Tests/UtilityTests.cs
+++ b/Tests/UtilityTests.cs
@@ -1,0 +1,21 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WindowsFormsApp1;
+
+namespace Trade_Csharp_25.Tests
+{
+    [TestClass]
+    public class UtilityTests
+    {
+        [TestMethod]
+        public void LoadCheck_DefaultsToFalse()
+        {
+            Assert.IsFalse(utility.load_check);
+        }
+
+        [TestMethod]
+        public void SystemRoute_EndsWithSettingTxt()
+        {
+            StringAssert.EndsWith(utility.system_route, "setting.txt");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add MSTest project targeting .NET Framework 4.7.2
- cover utility and form classes with baseline tests
- wire test project into existing solution

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b23b9bb8832e88e863a94369a852